### PR TITLE
chore(security): audit remediations (CodeQL, Dependabot, gitignore)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+.env.*
+*.pem
+*.key

--- a/assets/plugins/bootstrap/js/bootstrap.js
+++ b/assets/plugins/bootstrap/js/bootstrap.js
@@ -109,7 +109,7 @@ if (typeof jQuery === 'undefined') {
       selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    var $parent = $(selector)
+    var $parent = selector ? $.find(selector) : $()
 
     if (e) e.preventDefault()
 
@@ -502,7 +502,8 @@ if (typeof jQuery === 'undefined') {
   var clickHandler = function (e) {
     var href
     var $this   = $(this)
-    var $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) // strip for ie7
+    var sel = $this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') // strip for ie7
+    var $target = sel ? $.find(sel) : $()
     if (!$target.hasClass('carousel')) return
     var options = $.extend({}, $target.data(), $this.data())
     var slideIndex = $this.attr('data-slide-to')
@@ -691,7 +692,7 @@ if (typeof jQuery === 'undefined') {
     var target = $trigger.attr('data-target')
       || (href = $trigger.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') // strip for ie7
 
-    return $(target)
+    return target ? $.find(target) : $()
   }
 
 
@@ -773,7 +774,7 @@ if (typeof jQuery === 'undefined') {
       selector = selector && /#[A-Za-z]/.test(selector) && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    var $parent = selector && $(selector)
+    var $parent = selector && $.find(selector)
 
     return $parent && $parent.length ? $parent : $this.parent()
   }
@@ -1230,7 +1231,8 @@ if (typeof jQuery === 'undefined') {
   $(document).on('click.bs.modal.data-api', '[data-toggle="modal"]', function (e) {
     var $this   = $(this)
     var href    = $this.attr('href')
-    var $target = $($this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, ''))) // strip for ie7
+    var sel = $this.attr('data-target') || (href && href.replace(/.*(?=#[^\s]+$)/, '')) // strip for ie7
+    var $target = sel ? $.find(sel) : $()
     var option  = $target.data('bs.modal') ? 'toggle' : $.extend({ remote: !/#/.test(href) && href }, $target.data(), $this.data())
 
     if ($this.is('a')) e.preventDefault()
@@ -1299,7 +1301,12 @@ if (typeof jQuery === 'undefined') {
     this.type      = type
     this.$element  = $(element)
     this.options   = this.getOptions(options)
-    this.$viewport = this.options.viewport && $($.isFunction(this.options.viewport) ? this.options.viewport.call(this, this.$element) : (this.options.viewport.selector || this.options.viewport))
+    if (this.options.viewport) {
+      var viewportSpec = $.isFunction(this.options.viewport) ? this.options.viewport.call(this, this.$element) : (this.options.viewport.selector || this.options.viewport)
+      this.$viewport = typeof viewportSpec === 'string' ? $.find(viewportSpec) : $(viewportSpec)
+    } else {
+      this.$viewport = false
+    }
     this.inState   = { click: false, hover: false, focus: false }
 
     if (this.$element[0] instanceof document.constructor && !this.options.selector) {
@@ -1554,7 +1561,7 @@ if (typeof jQuery === 'undefined') {
     var $tip  = this.tip()
     var title = this.getTitle()
 
-    $tip.find('.tooltip-inner')[this.options.html ? 'html' : 'text'](title)
+    $tip.find('.tooltip-inner').text(title)
     $tip.removeClass('fade in top bottom left right')
   }
 
@@ -1808,16 +1815,20 @@ if (typeof jQuery === 'undefined') {
     var title   = this.getTitle()
     var content = this.getContent()
 
-    $tip.find('.popover-title')[this.options.html ? 'html' : 'text'](title)
-    $tip.find('.popover-content').children().detach().end()[ // we use append for html objects to maintain js events
-      this.options.html ? (typeof content == 'string' ? 'html' : 'append') : 'text'
-    ](content)
+    $tip.find('.popover-title').text(title)
+    var $contentEl = $tip.find('.popover-content')
+    $contentEl.children().detach().end()
+    if (typeof content == 'string') {
+      $contentEl.text(content)
+    } else {
+      $contentEl.append(content)
+    }
 
     $tip.removeClass('fade top bottom left right in')
 
     // IE8 doesn't accept hiding via the `:empty` pseudo selector, we have to do
     // this manually by checking the contents.
-    if (!$tip.find('.popover-title').html()) $tip.find('.popover-title').hide()
+    if (!$tip.find('.popover-title').text()) $tip.find('.popover-title').hide()
   }
 
   Popover.prototype.hasContent = function () {
@@ -2217,7 +2228,8 @@ if (typeof jQuery === 'undefined') {
   var Affix = function (element, options) {
     this.options = $.extend({}, Affix.DEFAULTS, options)
 
-    this.$target = $(this.options.target)
+    var target = this.options.target
+    this.$target = (typeof target === 'string' ? $.find(target) : $(target))
       .on('scroll.bs.affix.data-api', $.proxy(this.checkPosition, this))
       .on('click.bs.affix.data-api',  $.proxy(this.checkPositionWithEventLoop, this))
 


### PR DESCRIPTION
## Summary

Security audit remediations for `djdanielsson/djdanielsson.github.io`.

### Code scanning (CodeQL) — open alerts addressed
Eight open JavaScript alerts in `assets/plugins/bootstrap/js/bootstrap.js` (Bootstrap 3.3.6 vendored copy):

| Alert | Rule | Location (approx.) | Remediation |
|-------|------|-------------------|-------------|
| #1, #2, #3, #4, #5, #6 | `js/xss-through-dom` | Alert, carousel, collapse, dropdown, modal, tooltip `setContent`, popover `setContent` | Use `jQuery.find` for selector strings from DOM attributes; use `.text()` for tooltip/popover content instead of `.html()` where content is DOM-derived |
| #8, #12 | `js/unsafe-jquery-plugin` | Tooltip viewport init, Affix `options.target` | Avoid wrapping selector strings in `$(...)`; treat string targets with `$.find` |

Re-run CodeQL after merge to confirm alerts close.

### `pull_request_target`
No `.github/workflows/*.yml` or `*.yaml` files in this repository — **no `pull_request_target` usage found**. Nothing to change.

### Dependabot
- `.github/dependabot.yml` existed but used an invalid empty `package-ecosystem`.
- Replaced with **weekly** updates for **bundler** (`/`) and **github-actions** (`/`).
- No `.pre-commit-config.yaml` — pre-commit ecosystem not added.

### GitHub Actions
No workflow files under `.github/workflows` — no YAML to validate, no `permissions:` blocks or action pinning required in-repo.

### `.gitignore`
There was no repository-root `.gitignore`. Added entries for `.env`, `.env.*`, `*.pem`, and `*.key`.

---
**Note:** Tooltip/popover `html: true` no longer inserts raw HTML from `data-*` attributes; content is treated as text. If you rely on HTML tooltips/popovers, consider upgrading to a maintained Bootstrap major version or a sanitization library in a follow-up.

Made with [Cursor](https://cursor.com)